### PR TITLE
Update Mac-Health-Check with addition of Packet Firewall status check option

### DIFF
--- a/Mac-Health-Check.zsh
+++ b/Mac-Health-Check.zsh
@@ -69,6 +69,9 @@ organizationColorScheme="weight=semibold,colour1=#ef9d51,colour2=#ef7951"
 # Organization's Kerberos Realm (leave blank to disable check)
 kerberosRealm=""
 
+# Organization's Firewall Type [socketfilterfw | pf]
+organizationFirewall="socketfilterfw"
+
 # "Anticipation" Duration (in seconds)
 anticipationDuration="2"
 
@@ -1163,11 +1166,15 @@ function checkFirewall() {
 
     sleep "${anticipationDuration}"
 
-    firewallCheck=$( /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate )
+    if [[ "$organizationFirewall" == "socketfilterfw" ]]; then
+        firewallCheck=$( /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate )
+    elif [[ "$organizationFirewall" == "pf" ]]; then
+        firewallCheck=$( /sbin/pfctl -s info )
+    fi
 
     case ${firewallCheck} in
 
-        *"enabled"* ) 
+        *"enabled"* | *"Enabled"* )
             dialogUpdate "listitem: index: ${1}, status: success, statustext: Enabled"
             info "${humanReadableCheckName}: Enabled"
             ;;


### PR DESCRIPTION
This pull request adds the macOS packet firewall (pf) as an option to choose from in the firewall status section.

The organization can set the firewall type to use by setting the appropriate value in the Organization Variables section of the script:
```
# Organization's Firewall Type [socketfilterfw | pf]
organizationFirewall="socketfilterfw"
```

The default value is **socketfilterfw**