### PR TITLE
Update Firewall Cases to include one for State 2

### DIFF
--- a/Mac-Health-Check.zsh
+++ b/Mac-Health-Check.zsh
@@ -1167,12 +1167,7 @@ function checkFirewall() {
 
     case ${firewallCheck} in
 
-        *"enabled"* ) 
-            dialogUpdate "listitem: index: ${1}, status: success, statustext: Enabled"
-            info "${humanReadableCheckName}: Enabled"
-            ;;
-        
-        *"blocking all non-essential incoming connections"* ) 
+        *"enabled"* | *"Enabled"*  | *"is blocking"*) 
             dialogUpdate "listitem: index: ${1}, status: success, statustext: Enabled"
             info "${humanReadableCheckName}: Enabled"
             ;;

--- a/Mac-Health-Check.zsh
+++ b/Mac-Health-Check.zsh
@@ -1171,6 +1171,11 @@ function checkFirewall() {
             dialogUpdate "listitem: index: ${1}, status: success, statustext: Enabled"
             info "${humanReadableCheckName}: Enabled"
             ;;
+        
+        *"blocking all non-essential incoming connections"* ) 
+            dialogUpdate "listitem: index: ${1}, status: success, statustext: Enabled"
+            info "${humanReadableCheckName}: Enabled"
+            ;;
 
         *  )
             dialogUpdate "listitem: index: ${1}, status: fail, statustext: Failed"


### PR DESCRIPTION
State 2 the firewall is enabled but does not include the word Enabled in the return of the command .. Firewall/socketfilterfw --getglobalstate
/usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate Firewall is blocking all non-essential incoming connections. (State = 2) updated the cases so that this also returns as a successfull result