### PR TITLE
Fix for Free Disk Space comparison bug (issue #10)

### DIFF
--- a/Mac-Health-Check.zsh
+++ b/Mac-Health-Check.zsh
@@ -1273,7 +1273,7 @@ function checkFreeDiskSpace() {
 
     diskMessage="${humanReadableCheckName}: ${diskSpace}"
 
-    if [[ "${freePercentage}" < "${allowedMinimumFreeDiskPercentage}" ]]; then
+    if (( $(echo ${freePercentage}'<'${allowedMinimumFreeDiskPercentage} |bc -l) )); then
 
         dialogUpdate "listitem: index: ${1}, status: fail, statustext: ${diskSpace}"
         errorOut "${humanReadableCheckName}: ${diskSpace}"


### PR DESCRIPTION
This fixes the comparison logic so that values below the allowedMinimumFreeDiskPercentage will result in a failed test.

Before bug fix:
<img width="620" height="80" alt="Screenshot 2025-07-23 at 6 16 55 PM" src="https://github.com/user-attachments/assets/a674fcd2-ec27-4566-81e8-baedf5c16fd2" />

After bug fix:
<img width="622" height="78" alt="Screenshot 2025-07-23 at 7 52 43 PM" src="https://github.com/user-attachments/assets/0b07095b-400f-413a-9695-6a3bea2f02b1" />
