### PR TITLE
Update Mac-Health-Check.zsh

### DIFF
--- a/Mac-Health-Check.zsh
+++ b/Mac-Health-Check.zsh
@@ -98,6 +98,9 @@ excessiveUptimeAlertStyle="warning"
 # Completion Timer (in seconds)
 completionTimer="60"
 
+# Organization's MDM Profile UUID
+# You can find this out by using: sudo profiles show enrollment
+organizationMDMuuid="00000000-0000-0000-A000-4A414D460003"
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -1495,7 +1498,7 @@ function checkJamfProMdmProfile() {
 
     sleep "${anticipationDuration}"
 
-    mdmProfileTest=$( profiles list -all | grep "00000000-0000-0000-A000-4A414D460003" )
+    mdmProfileTest=$( profiles list -all | grep $organizationMDMuuid )
 
     if [[ -n "${mdmProfileTest}" ]]; then
 
@@ -1528,7 +1531,7 @@ function checkMosyleMdmProfile() {
 
     sleep "${anticipationDuration}"
 
-    mdmProfileTest=$( profiles show enrollment | grep "00000000-0000-0000-A000-4A414D460003" )
+    mdmProfileTest=$( profiles show enrollment | grep $organizationMDMuuid )
 
     if [[ -n "${mdmProfileTest}" ]]; then
 


### PR DESCRIPTION
Place an organization variable at the top of the script called "organizationMDMuuid" to make it easier to grep for it later when doing the Profile check for Jamf or Mosyle (or whatever)