### PR TITLE
Add framework for different VPN clients and an internal VPN Client Check to Mac-Health-Check

### DIFF
--- a/Mac-Health-Check.zsh
+++ b/Mac-Health-Check.zsh
@@ -276,14 +276,14 @@ if [[ "${vpnClientType}" == "paloalto" ]]; then
     vpnStatus="GlobalProtect is NOT installed"
     if [[ -d "/Applications/GlobalProtect.app" ]]; then
         vpnStatus="GlobalProtect is Idle"
-        globalProtectVPNStatus=$(ifconfig gpd0 | awk '/<UP/ {print $2}')
-        globalProtectVPNIP=$(ifconfig gpd0 | awk '/broadcast/ {print $2}')
+        globalProtectInterface=$(netstat -nr | grep utun| head -1| awk '{ print $4 }')
+        globalProtectVPNStatus=$(ifconfig $globalProtectInterface | awk '/inet / {print $2}')
 
-        if [[ ! -z "${globalProtectVPNStatus}" ]]; then
-            vpnStatus="${globalProtectVPNIP}"
+        if [[ -n "${globalProtectVPNStatus}" ]]; then
+            vpnStatus="${globalProtectVPNStatus}"
         fi
     fi
-    if [[ "${vpnClientDataType}" == "extended" ]] && [[ ! -z "${globalProtectVPNStatus}" ]]; then
+    if [[ "${vpnClientDataType}" == "extended" ]] && [[ -n "${globalProtectVPNStatus}" ]]; then
         globalProtectStatus=$( /usr/libexec/PlistBuddy -c "print :Palo\ Alto\ Networks:GlobalProtect:PanGPS:disable-globalprotect" /Library/Preferences/com.paloaltonetworks.GlobalProtect.settings.plist )
         case "${globalProtectStatus}" in
             0 ) globalProtectDisabled="GlobalProtect Running; " ;;


### PR DESCRIPTION
This change lays a potential framework for adding additional supported VPN clients to the Mac-Health-Check script. It does so by replacing the previous PaloAlto GlobalProtect check block with a new one and adding support for the Cisco VPN client.

Two new new organizational variables have been added to help configure the script:
```
# Organization's VPN client type [none | paloalto | cisco]
vpnClientType="none"

# Organization's VPN data type [basic | extended]
vpnClientDataType="basic"
```

Setting the client type to `none` will make the script forego all VPN network information checks and make the separate VPN Client check automatically pass.

Setting the client type to `paloalto` will enable support for the GlobalProtect VPN client and allow it to collect data for that client only.

Setting the client type to `cisco` will enable support for the Cisco AnyConnect or Secure Client VPN client and allow it to collect data for that client only.

Setting the data type to `basic` (the default) will cause the script to only collect the IP address of the VPN client when connected.

Setting the data type to `extended` will collect additional information from the VPN Client as outlined below.  This information will only appear in the logs when Mac-Health-Check is run and are currently not displayed in the user interface.

**PaloAlto GlobalProtect VPN Client** 
GlobalProtect VPN client is checked to see if it is disabled
A check is made to see if the logged in user is also the user account logging into GlobalProtect
(These checks were based on the external check for GlobalProtect which should no longer need to be enabled)

**Cisco VPN Client**
The VPN Server address is collected
The current VPN connection duration is collected
The current VPN connection session automatic disconnect time is collected

**Important Note:** The extended information is only collected if a VPN connection is active when Mac-Health-Check runs and the data type variable is set to `extended`.

Finally, the line item VPN Client check included will report an error if the respective VPN client is not installed. It will treat an Idle or Connected VPN Client as passing the test. 
