### PR TITLE
Active IP Address section changes

### DIFF
--- a/Mac-Health-Check.zsh
+++ b/Mac-Health-Check.zsh
@@ -234,21 +234,22 @@ fi
 ####################################################################################################
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# Wi-Fi IP Address
+# Active IP Address
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 networkServices=$( networksetup -listallnetworkservices | grep -v asterisk )
 
 while IFS= read -r aService; do
     activePort=$( networksetup -getinfo "$aService" | grep "IP address" | grep -v "IPv6" )
+    activePort=${activePort/IP address: /}
     if [ "$activePort" != "" ] && [ "$activeServices" != "" ]; then
-        activeServices="$activeServices\n$aService $activePort"
+        activeServices="$activeServices\n**$aService IP:** $activePort"
     elif [ "$activePort" != "" ] && [ "$activeServices" = "" ]; then
-        activeServices="$aService $activePort"
+        activeServices="**$aService IP:** $activePort"
     fi
 done <<< "$networkServices"
 
-wiFiIpAddress=$( echo "$activeServices" | sed '/^$/d' | head -n 1 )
+activeIPAddress=$( echo "$activeServices" | sed '/^$/d' | head -n 1 )
 
 
 
@@ -393,7 +394,7 @@ supportKBURL="[${supportKB}](${infobuttonaction})"
 # Help Message Variables
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-helpmessage="For assistance, please contact: **${supportTeamName}**<br>- **Telephone:** ${supportTeamPhone}<br>- **Email:** ${supportTeamEmail}<br>- **Website:** ${supportTeamWebsite}<br>- **Knowledge Base Article:** ${supportKBURL}<br><br>**User Information:**<br>- **Full Name:** ${loggedInUserFullname}<br>- **User Name:** ${loggedInUser}<br>- **User ID:** ${loggedInUserID}<br>- **Secure Token:** ${secureToken}<br>- **Location Services:** ${locationServicesStatus}<br>- **Microsoft OneDrive Sync Date:** ${oneDriveSyncDate}<br>- **Platform SSOe:** ${platformSSOeResult}<br><br>**Computer Information:**<br>- **macOS:** ${osVersion} (${osBuild})<br>- **Computer Name:** ${computerName}<br>- **Serial Number:** ${serialNumber}<br>- **Wi-Fi:** ${ssid}<br>- ${wiFiIpAddress}<br>- **VPN IP:** ${vpnStatus}<br><br>**Jamf Pro Information:**<br>- **Site:** ${jamfProSiteName}"
+helpmessage="For assistance, please contact: **${supportTeamName}**<br>- **Telephone:** ${supportTeamPhone}<br>- **Email:** ${supportTeamEmail}<br>- **Website:** ${supportTeamWebsite}<br>- **Knowledge Base Article:** ${supportKBURL}<br><br>**User Information:**<br>- **Full Name:** ${loggedInUserFullname}<br>- **User Name:** ${loggedInUser}<br>- **User ID:** ${loggedInUserID}<br>- **Secure Token:** ${secureToken}<br>- **Location Services:** ${locationServicesStatus}<br>- **Microsoft OneDrive Sync Date:** ${oneDriveSyncDate}<br>- **Platform SSOe:** ${platformSSOeResult}<br><br>**Computer Information:**<br>- **macOS:** ${osVersion} (${osBuild})<br>- **Computer Name:** ${computerName}<br>- **Serial Number:** ${serialNumber}<br>- **Wi-Fi:** ${ssid}<br>- ${activeIPAddress}<br>- **VPN IP:** ${vpnStatus}<br><br>**Jamf Pro Information:**<br>- **Site:** ${jamfProSiteName}"
 
 helpimage="qr=${infobuttonaction}"
 
@@ -725,7 +726,7 @@ function quitScript() {
 
     quitOut "Exiting …"
 
-    notice "${localAdminWarning}User: ${loggedInUserFullname} (${loggedInUser}) [${loggedInUserID}] ${loggedInUserGroupMembership}; ${bootstrapTokenStatus}; sudo Check: ${sudoStatus}; sudoers: ${sudoAllLines}; Kerberos SSOe: ${kerberosSSOeResult}; Platform SSOe: ${platformSSOeResult}; Location Services: ${locationServicesStatus}; SSH: ${sshStatus}; Microsoft OneDrive Sync Date: ${oneDriveSyncDate}; Time Machine Backup Date: ${tmStatus} ${tmLastBackup}; Battery Cycle Count: ${batteryCycleCount}; Wi-Fi: ${ssid}; ${wiFiIpAddress}; VPN IP: ${vpnStatus} ${vpnExtendedStatus}; ${networkTimeServer}; Jamf Pro Computer ID: ${jamfProID}; Site: ${jamfProSiteName}"
+    notice "${localAdminWarning}User: ${loggedInUserFullname} (${loggedInUser}) [${loggedInUserID}] ${loggedInUserGroupMembership}; ${bootstrapTokenStatus}; sudo Check: ${sudoStatus}; sudoers: ${sudoAllLines}; Kerberos SSOe: ${kerberosSSOeResult}; Platform SSOe: ${platformSSOeResult}; Location Services: ${locationServicesStatus}; SSH: ${sshStatus}; Microsoft OneDrive Sync Date: ${oneDriveSyncDate}; Time Machine Backup Date: ${tmStatus} ${tmLastBackup}; Battery Cycle Count: ${batteryCycleCount}; Wi-Fi: ${ssid}; ${activeIPAddress//\*\*/}; VPN IP: ${vpnStatus} ${vpnExtendedStatus}; ${networkTimeServer}; Jamf Pro Computer ID: ${jamfProID}; Site: ${jamfProSiteName}"
 
     if [[ -n "${overallHealth}" ]]; then
         dialogUpdate "icon: SF=xmark.circle,weight=bold,colour1=#BB1717,colour2=#F31F1F"


### PR DESCRIPTION
This changes the section name from "Wi-Fi IP Address" to "Active IP Address" since that is really what is being collected.

This changes the formatting and adds the markup to the line in the Help Message window to conform to the same format as the VPN IP and the other fields shown.

BEFORE Change
<img width="290" height="32" alt="Screenshot 2025-07-29 at 11 04 25 AM" src="https://github.com/user-attachments/assets/6ec2310e-0196-4d6c-a52c-e7cc31805f49" />
<img width="276" height="34" alt="Screenshot 2025-07-29 at 11 13 53 AM" src="https://github.com/user-attachments/assets/a4f4e86b-6bed-461a-9c28-96290ab0301b" />

AFTER Change
<img width="184" height="31" alt="Screenshot 2025-07-29 at 10 38 35 AM" src="https://github.com/user-attachments/assets/b806bd3c-7e53-4096-b9b1-2746adc5947c" />
<img width="282" height="30" alt="Screenshot 2025-07-29 at 10 36 02 AM" src="https://github.com/user-attachments/assets/f1debeb3-5807-4dca-8c11-3f75f339c56e" />

This change removes the extra formatting and just displays the information in the closing notice which is what is displayed in the log information.

<img width="462" height="21" alt="Screenshot 2025-07-29 at 11 10 43 AM" src="https://github.com/user-attachments/assets/0c993318-f364-4c8e-84a6-7d3a9d141b84" />
