### PR TITLE
Update Mac-Health-Check.zsh

### DIFF
--- a/Mac-Health-Check.zsh
+++ b/Mac-Health-Check.zsh
@@ -1410,7 +1410,7 @@ function checkJssCertificateExpiration() {
 
     sleep "${anticipationDuration}"
 
-    identities=( $( security find-identity -v /Library/Keychains/System.keychain | awk '{print $3}' | tr -d '"' | head -n 1 ) )
+    identities=( $( security find-identity -v /Library/Keychains/System.keychain | grep -v "$serialNumber" | awk '{print $3}' | tr -d '"' | head -n 1 ) )
     now_seconds=$( date +%s )
 
     if [[ "${identities}" != "identities" ]]; then


### PR DESCRIPTION
In rare occasions, multiple security entries will be returned. Added in code to exclude entires that match the Mac serial #