### PR TITLE
Force locale to English for date command

### DIFF
--- a/Mac-Health-Check.zsh
+++ b/Mac-Health-Check.zsh
@@ -2789,6 +2789,9 @@ function checkMdmCertificateExpiration() {
         return
     fi
 
+	# force locale to english so 'date' does not error on any localization formatting issues
+	LANG=en_us_88591;
+
     now_seconds=$(date +%s)
     date_seconds=$(date -j -f "%b %d %T %Y %Z" "$expiry" +%s)
     expirationDateFormatted=$(date -j -f "%b %d %H:%M:%S %Y GMT" "$expiry" "+%d-%b-%Y")


### PR DESCRIPTION
Set locale to English to avoid date formatting errors. 

See also https://github.com/dan-snelson/Mac-Health-Check/issues/1#issuecomment-3702107671