### PR TITLE
Fix: SSO checks report 'not configured' instead of 'NOT logged in' when SSO type is absent

### DIFF
--- a/Mac-Health-Check.zsh
+++ b/Mac-Health-Check.zsh
@@ -380,8 +380,8 @@ kerberosSSOeResult="Not configured"
 
 # Kerberos Single Sign-on Extension
 if [[ -n "${kerberosRealm}" ]]; then
-    su \- "${loggedInUser}" -c "app-sso kerberos --realminfo ${kerberosRealm}" > /var/tmp/app-sso.plist
-    if xmllint --noout /var/tmp/app-sso.plist >/dev/null 2>&1; then
+    su \- "${loggedInUser}" -c "app-sso kerberos --realminfo ${kerberosRealm}" > /var/tmp/app-sso.plist 2>/dev/null
+    if [[ -f /var/tmp/app-sso.plist ]] && xmllint --noout /var/tmp/app-sso.plist >/dev/null 2>&1; then
         ssoLoginTest=$( /usr/libexec/PlistBuddy -c "Print:login_date" /var/tmp/app-sso.plist 2>&1 )
         if [[ ${ssoLoginTest} == *"Does Not Exist"* ]]; then
             kerberosSSOeResult="${loggedInUser} NOT logged in"
@@ -396,9 +396,9 @@ if [[ -n "${kerberosRealm}" ]]; then
             fi
         fi
     else
-        kerberosSSOeResult="${loggedInUser} NOT logged in"
+        kerberosSSOeResult="Kerberos SSO not configured"
     fi
-    rm -f /var/tmp/app-sso.plist
+    rm -f /var/tmp/app-sso.plist 2>/dev/null
 fi
 
 # Platform Single Sign-on Extension
@@ -412,7 +412,7 @@ if [[ -n "${pssoeEmail}" ]]; then
         fi
     fi
 else
-    platformSSOeResult="${loggedInUser} NOT logged in"
+    platformSSOeResult="Platform SSO not configured"
 fi
 
 # Last modified time of user's Microsoft OneDrive sync file (thanks, @pbowden-msft!)


### PR DESCRIPTION
Addresses the companion case to #81 where SSO checks display "NOT logged in" results when a particular SSO type isn't configured on the machine.
### Changes:

- Added file-existence check alongside xmllint, so a missing or empty plist falls through to "Kerberos SSO not configured" rather than "NOT logged in"
- Changed Kerberos SSOe fallback message from "${loggedInUser} NOT logged in" to "Kerberos SSO not configured"
- Changed Platform SSOe fallback from "${loggedInUser} NOT logged in" to "Platform SSO not configured"


### Tested against:

- PSSO-active / Kerberos-inactive machine: previously showed **`first.last` NOT logged in**, now shows **Kerberos SSO not configured**
- Kerberos-active / PSSO-inactive machine: previously showed **`netID` NOT logged in**, now shows **Platform SSO not configured**