### PR TITLE
Update staged macOS update check

### DIFF
--- a/Mac-Health-Check.zsh
+++ b/Mac-Health-Check.zsh
@@ -5822,7 +5822,7 @@ function checkStagedUpdate() {
     local stagedUpdateStatus="Pending download"
     
     # Check for APFS snapshots indicating staged updates
-    local updateSnapshots=$(tmutil listlocalsnapshots / 2>/dev/null | grep -c "com.apple.os.update")
+    local updateSnapshots=$(/usr/sbin/diskutil apfs listsnapshots / 2>/dev/null | grep -c "com.apple.os.update")
     
     if [[ ${updateSnapshots} -gt 0 ]]; then
         info "Found ${updateSnapshots} update snapshot(s)"


### PR DESCRIPTION
Updated the system call that is used to check for staged macOS updates to prevent a possible conflict if Time Machine is ever blocked.