### PR TITLE
4.1.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ Out of scope:
 - `Development` is intentionally curated, not representative of full suite; when changing checks or list items, verify whether `developmentListitemJSON` also needs update.
 
 ## Repository Rules
-- Current branch prepares `4.0.0`; use `VERSION.txt`, `scriptVersion`, and `CHANGELOG.md` as release-state truth.
+- Current branch prepares `4.1.0`; use `VERSION.txt`, `scriptVersion`, and `CHANGELOG.md` as release-state truth.
 - Keep `scriptVersion` inside script aligned with `VERSION.txt` at all times.
 - Current beta expects swiftDialog `3.1.0.4994` or newer; treat older version references as documentation debt unless task is explicitly historical.
 - Check `git status` before editing shared docs or assets so unrelated local work is not overwritten.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## CHANGELOG
 
-### 4.1.0b3 (13-Aug-2026)
+### 4.1.0b4 (13-Aug-2026)
+- Updated detached Inspect Mode Preset 6 dialogs to remain on top and allow users to move the window (thanks for the suggestion, @TechTrekkie!)
 - Hardened staged macOS update snapshot detection to use APFS-native `diskutil` with timeout-safe fallback behavior (thanks for PR #99, @HowardGMac!)
 - Updated `checkUptime()` with new functionality (thanks for PR #96, @HowardGMac!)
 - Standardized `checkUptime()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## CHANGELOG
 
-### 4.1.0b4 (13-Aug-2026)
+### 4.1.0b6 (13-Aug-2026)
+- Refactored `checkBluetoothSharing()` to recognize the macOS 27 missing-domain response as the disabled default, preventing false-positive Bluetooth Sharing findings while preserving enabled-state detection on macOS 26 and macOS 27
 - Updated detached Inspect Mode Preset 6 dialogs to remain on top and allow users to move the window (thanks for the suggestion, @TechTrekkie!)
 - Hardened staged macOS update snapshot detection to use APFS-native `diskutil` with timeout-safe fallback behavior (thanks for PR #99, @HowardGMac!)
 - Updated `checkUptime()` with new functionality (thanks for PR #96, @HowardGMac!)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## CHANGELOG
 
-### 4.1.0b2 (17-Jul-2026)
+### 4.1.0b3 (13-Aug-2026)
+- Hardened staged macOS update snapshot detection to use APFS-native `diskutil` with timeout-safe fallback behavior (thanks for PR #99, @HowardGMac!)
 - Updated `checkUptime()` with new functionality (thanks for PR #96, @HowardGMac!)
 - Standardized `checkUptime()`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## CHANGELOG
 
-### 4.1.0b6 (13-Aug-2026)
+### 4.1.0 (17-Aug-2026)
 - Refactored `checkBluetoothSharing()` to recognize the macOS 27 missing-domain response as the disabled default, preventing false-positive Bluetooth Sharing findings while preserving enabled-state detection on macOS 26 and macOS 27
 - Updated detached Inspect Mode Preset 6 dialogs to remain on top and allow users to move the window (thanks for the suggestion, @TechTrekkie!)
 - Hardened staged macOS update snapshot detection to use APFS-native `diskutil` with timeout-safe fallback behavior (thanks for PR #99, @HowardGMac!)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## CHANGELOG
 
-### 4.1.0b1 (17-Jul-2026)
+### 4.1.0b2 (17-Jul-2026)
 - Updated `checkUptime()` with new functionality (thanks for PR #96, @HowardGMac!)
+- Standardized `checkUptime()`
 
 ### 4.0.0 (16-Jul-2026)
 - Raised the minimum required swiftDialog version to `3.1.0.4994` and refactored pre-flight checks to skip redundant production package downloads when the installed release already matches the latest production build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## CHANGELOG
 
+### 4.1.0b1 (17-Jul-2026)
+- Updated `checkUptime()` with new functionality (thanks for PR #96, @HowardGMac!)
+
 ### 4.0.0 (16-Jul-2026)
 - Raised the minimum required swiftDialog version to `3.1.0.4994` and refactored pre-flight checks to skip redundant production package downloads when the installed release already matches the latest production build
 - Added JSON health reporting with optional Splunk HTTP Event Collector (HEC) delivery, plus stricter cached-report validation so failed cached uploads no longer look like successful report generation

--- a/Mac-Health-Check.zsh
+++ b/Mac-Health-Check.zsh
@@ -4676,7 +4676,7 @@ function validateInspectConfigFile() {
                 and (.category | length > 0)
             )
         )
-        and (.height == 750)
+        and (.height == 850)
         and (.width == 975)
         and (.items | type == "array")
         and (.items | length >= 3)
@@ -5863,7 +5863,17 @@ function checkStagedUpdate() {
 
     if [[ -z "${systemVolumeUUID}" ]]; then
         info "No Preboot UUID directory found; staging cannot be evaluated."
-        updateStagingStatus="Pending download"
+        updateStagedSize="${stagedUpdateSize}"
+        updateStagedLocation="${stagedUpdateLocation}"
+        updateStagingStatus="${stagedUpdateStatus}"
+        case "${updateStagingStatus}" in
+            "Partially staged")
+                stagingMessage="Preparing update …"
+                ;;
+            *)
+                stagingMessage="Will start download when you open System Settings > General > Software Update"
+                ;;
+        esac
         return
     fi
 
@@ -6643,7 +6653,8 @@ function checkUptime() {
     uptimeDays=$( uptime | awk '{ print $4 }' | sed 's/,//g' )
     uptimeNumber=$( uptime | awk '{ print $3 }' | sed 's/,//g' )
 
-    uptimeExtendedStatus="Thanks for restarting your Mac regularly."
+    local uptimeExtendedStatus="Thanks for restarting your Mac regularly."
+    local effectiveMaxUptimeMinutes="${maxUptimeMinutes}"
 
     if [[ "${uptimeDays}" = "day"* ]]; then
         if [[ "${uptimeNumber}" -gt 1 ]]; then
@@ -6657,20 +6668,22 @@ function checkUptime() {
         uptimeHumanReadable="${uptimeNumber} (HH:MM)"
     fi
     
-    if [[ "${maxUptimeMinutes}" =~ '^[1-9][0-9]*$' ]]; then
-        if [[ "${allowedUptimeMinutes}" -gt "${maxUptimeMinutes}" ]]; then
-            warning "${humanReadableCheckName}: Error in configuration: Variable allowedUptimeMinutes is greater than maxUptimeMinutes. Maximum uptime check disabled."
-            maxUptimeMinutes=""
-        elif [[ -n "${maxUptimeMinutes}" ]] && [[ "${excessiveUptimeAlertStyle}" == "error" ]]; then
-            warning "${humanReadableCheckName}: Error in configuration: Variable excessiveUptimeAlertStyle is set to error instead of warning. Maximum uptime check disabled."
-            maxUptimeMinutes=""
+    if [[ -n "${effectiveMaxUptimeMinutes}" ]]; then
+        if [[ "${effectiveMaxUptimeMinutes}" =~ '^[1-9][0-9]*$' ]]; then
+            if [[ "${allowedUptimeMinutes}" -gt "${effectiveMaxUptimeMinutes}" ]]; then
+                warning "${humanReadableCheckName}: Error in configuration: Variable allowedUptimeMinutes is greater than maxUptimeMinutes. Maximum uptime check disabled."
+                effectiveMaxUptimeMinutes=""
+            elif [[ "${excessiveUptimeAlertStyle}" == "error" ]]; then
+                warning "${humanReadableCheckName}: Error in configuration: Variable excessiveUptimeAlertStyle is set to error instead of warning. Maximum uptime check disabled."
+                effectiveMaxUptimeMinutes=""
+            fi
+        else
+            warning "${humanReadableCheckName}: Error in configuration: Variable maxUptimeMinutes is not a positive integer. Maximum uptime check disabled."
+            effectiveMaxUptimeMinutes=""
         fi
-    else
-            warning "${humanReadableCheckName}: Error in configuration: Variable maxUptimeMinutes is not a postive integer. Maximum uptime check disabled."
-            maxUptimeMinutes=""
     fi
 
-    if [[ -n "${maxUptimeMinutes}" ]] && [[ "${upTimeMin}" -gt "${maxUptimeMinutes}" ]]; then
+    if [[ -n "${effectiveMaxUptimeMinutes}" ]] && [[ "${upTimeMin}" -gt "${effectiveMaxUptimeMinutes}" ]]; then
         local uptimeExtendedStatus="Your Mac's uptime is beyond the maximum allowed by your organization."
         dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=bold colour=${statusColorFail}, iconalpha: 1, subtitle: ${uptimeExtendedStatus}, status: fail, statustext: ${uptimeHumanReadable}"
         errorOut "${humanReadableCheckName}: ${uptimeHumanReadable}: ${uptimeExtendedStatus}"
@@ -8560,7 +8573,7 @@ function checkBluetoothSharing() {
     result=$( captureRunAsUserOutput defaults -currentHost read com.apple.Bluetooth PrefKeyServicesEnabled )
 
     # A missing preference retains macOS's disabled default; macOS 27 reports a missing domain differently.
-    if [[ "${result}" == "0" ]] || [[ "${result}" == *"does not exist"* ]] || [[ "${result}" == "Error: Domain 'com.apple.Bluetooth' not found." ]]; then
+    if [[ "${result}" == "0" ]] || [[ "${result}" == *"does not exist"* ]] || [[ "${result}" == *"Domain 'com.apple.Bluetooth' not found"* ]]; then
         info "${humanReadableCheckName}: Disabled"
         dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=semibold colour=${statusColorSuccess}, iconalpha: 0.9, subtitle: ${organizationBoilerplateComplianceMessage}, status: success, statustext: Disabled"
     else
@@ -8982,9 +8995,9 @@ if [[ "${operationMode}" == "Development" ]]; then
     # Operation Mode: Development
     notice "Operation Mode is ${operationMode}; using ${operationMode}-specific Health Check."
     dialogUpdate "title: ${humanReadableScriptName} (${scriptVersion})<br>Operation Mode: ${operationMode}"
-    set -x
+    # set -x
     checkBluetoothSharing "0"
-    set +x
+    # set +x
 
 else
 

--- a/Mac-Health-Check.zsh
+++ b/Mac-Health-Check.zsh
@@ -391,7 +391,10 @@ sofaCacheMaximumAge="1d"
 # Allowed number of uptime minutes
 # - 1 day = 24 hours × 60 minutes/hour = 1,440 minutes
 # - 7 days, multiply: 7 × 1,440 minutes = 10,080 minutes
+# - 30 days, multiply: 30 × 1,440 minutes = 43,200 minutes
+# Use maxUptimeMinutes="" to turn the max uptime check off if desired.
 allowedUptimeMinutes="10080"
+maxUptimeMinutes="43200"
 
 # Should excessive uptime result in a "warning" or "error" ?
 excessiveUptimeAlertStyle="warning"
@@ -6600,13 +6603,12 @@ function checkFirewall() {
 function checkUptime() {
 
     local humanReadableCheckName="Uptime"
-    local footerStatusColor="${statusColorSuccess}"
-    notice "Check ${humanReadableCheckName} …"
+    notice "Check ${humanReadableCheckName} ..."
 
     dialogUpdate "icon: SF=stopwatch,${organizationColorScheme}"
-    dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill $(echo "${organizationColorScheme}" | tr ',' ' '), iconalpha: 1, status: wait, statustext: Checking …"
+    dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill $(echo "${organizationColorScheme}" | tr ',' ' '), iconalpha: 1, status: wait, statustext: Checking ..."
     dialogUpdate "progress: increment"
-    dialogUpdate "progresstext: Calculating time since last reboot …"
+    dialogUpdate "progresstext: Calculating time since last reboot ..."
 
     sleep "${anticipationDuration}"
 
@@ -6618,6 +6620,8 @@ function checkUptime() {
     upTimeHours=$((upTimeMin/60))
     uptimeDays=$( uptime | awk '{ print $4 }' | sed 's/,//g' )
     uptimeNumber=$( uptime | awk '{ print $3 }' | sed 's/,//g' )
+
+    uptimeExtendedStatus="Thanks for restarting your Mac regularly."
 
     if [[ "${uptimeDays}" = "day"* ]]; then
         if [[ "${uptimeNumber}" -gt 1 ]]; then
@@ -6631,38 +6635,33 @@ function checkUptime() {
         uptimeHumanReadable="${uptimeNumber} (HH:MM)"
     fi
 
-    if [[ "${upTimeMin}" -gt "${allowedUptimeMinutes}" ]]; then
-
+    if [[ "${upTimeMin}" -gt "${maxUptimeMinutes}" ]] && [[ -n "${maxUptimeMinutes}" ]]; then
+        uptimeExtendedStatus="Your Mac's uptime is beyond the maximum 30 days allowed."
+        dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=bold colour=${statusColorFail}, iconalpha: 1, subtitle: ${uptimeExtendedStatus}, status: fail, statustext: ${uptimeHumanReadable}"
+        errorOut "${humanReadableCheckName}: ${uptimeHumanReadable}: "
+        overallHealth+="${humanReadableCheckName}; "
+    elif [[ "${upTimeMin}" -gt "${allowedUptimeMinutes}" ]]; then
+        uptimeExtendedStatus="Please restart your Mac regularly. "
         case ${excessiveUptimeAlertStyle} in
 
-            "warning" ) 
-                dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=bold colour=${statusColorError}, iconalpha: 1, subtitle: Please restart your Mac regularly, status: error, statustext: ${uptimeHumanReadable}"
-                footerStatusColor="${statusColorError}"
-                warning "${humanReadableCheckName}: ${uptimeHumanReadable}"
+            "warning" )
+                dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=bold colour=${statusColorError}, iconalpha: 1, subtitle: ${uptimeExtendedStatus}, status: error, statustext: ${uptimeHumanReadable}"
+                warning "${humanReadableCheckName}: ${uptimeHumanReadable}: "
                 ;;
 
-            "error" | * )
-                dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=bold colour=${statusColorFail}, iconalpha: 1, subtitle: Please restart your Mac regularly, status: fail, statustext: ${uptimeHumanReadable}"
-                footerStatusColor="${statusColorFail}"
-                errorOut "${humanReadableCheckName}: ${uptimeHumanReadable}"
+            "error" )
+                dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=bold colour=${statusColorFail}, iconalpha: 1, subtitle: ${uptimeExtendedStatus}, status: fail, statustext: ${uptimeHumanReadable}"
+                errorOut "${humanReadableCheckName}: ${uptimeHumanReadable}: "
                 overallHealth+="${humanReadableCheckName}; "
                 ;;
 
         esac
-    
     else
-    
-        dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=semibold colour=${statusColorSuccess}, iconalpha: 0.9, subtitle: Thanks for restarting your Mac regularly, status: success, statustext: ${uptimeHumanReadable}"
-        footerStatusColor="${statusColorSuccess}"
-        info "${humanReadableCheckName}: ${uptimeHumanReadable}"
-    
+        dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=semibold colour=${statusColorSuccess}, iconalpha: 0.6, subtitle: ${uptimeExtendedStatus}, status: success, statustext: ${uptimeHumanReadable}"
+        info "${humanReadableCheckName}: ${uptimeHumanReadable}: "   
     fi
 
-    dialogUpdate "icon: SF=stopwatch,weight=semibold,colour=${footerStatusColor}"
-    sleep $((anticipationDuration / 2))
-
 }
-
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #

--- a/Mac-Health-Check.zsh
+++ b/Mac-Health-Check.zsh
@@ -17,7 +17,7 @@
 #
 # HISTORY
 #
-# Version 4.1.0b3, 13-Aug-2026, Dan K. Snelson (@dan-snelson)
+# Version 4.1.0b4, 13-Aug-2026, Dan K. Snelson (@dan-snelson)
 # - See CHANGELOG.md for details
 #
 ####################################################################################################
@@ -33,7 +33,7 @@
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/
 
 # Script Version
-scriptVersion="4.1.0b3"
+scriptVersion="4.1.0b4"
 
 # Client-side Log
 scriptLog="/var/log/org.churchofjesuschrist.log"
@@ -4621,7 +4621,7 @@ function buildInspectItemsJSONArray() {
 function buildInspectConfigJSON() {
 
     local inspectHighlightColor="#F69325"
-    local inspectWindowHeight="750"
+    local inspectWindowHeight="850"
     local inspectWindowWidth="975"
 
     printf '%s' "{"
@@ -4920,7 +4920,7 @@ function launchInspectSummary() {
         return 1
     fi
 
-    launchCommand="/usr/bin/nohup /usr/bin/env DIALOG_INSPECT_CONFIG=${(q)inspectConfigToLaunch} DIALOG_DEBUG=1 ${(q)dialogBinary} --inspect-mode --inspect-config ${(q)inspectConfigToLaunch} >${(q)inspectLaunchLogPath} 2>&1 </dev/null & print -r -- \$!"
+    launchCommand="/usr/bin/nohup /usr/bin/env DIALOG_INSPECT_CONFIG=${(q)inspectConfigToLaunch} DIALOG_DEBUG=1 ${(q)dialogBinary} --inspect-mode --inspect-config ${(q)inspectConfigToLaunch} --ontop --moveable >${(q)inspectLaunchLogPath} 2>&1 </dev/null & print -r -- \$!"
     inspectPID="$( runAsUser /bin/zsh -lc "${launchCommand}" 2>/dev/null | tr -d '[:space:]' )"
 
     if [[ ! "${inspectPID}" == <-> ]]; then

--- a/Mac-Health-Check.zsh
+++ b/Mac-Health-Check.zsh
@@ -17,7 +17,7 @@
 #
 # HISTORY
 #
-# Version 4.1.0b6, 13-Aug-2026, Dan K. Snelson (@dan-snelson)
+# Version 4.1.0, 17-Aug-2026, Dan K. Snelson (@dan-snelson)
 # - See CHANGELOG.md for details
 #
 ####################################################################################################
@@ -33,7 +33,7 @@
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/
 
 # Script Version
-scriptVersion="4.1.0b6"
+scriptVersion="4.1.0"
 
 # Client-side Log
 scriptLog="/var/log/org.churchofjesuschrist.log"

--- a/Mac-Health-Check.zsh
+++ b/Mac-Health-Check.zsh
@@ -17,7 +17,7 @@
 #
 # HISTORY
 #
-# Version 4.1.0b1, 17-Jul-2026, Dan K. Snelson (@dan-snelson)
+# Version 4.1.0b2, 17-Jul-2026, Dan K. Snelson (@dan-snelson)
 # - See CHANGELOG.md for details
 #
 ####################################################################################################
@@ -33,7 +33,7 @@
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/
 
 # Script Version
-scriptVersion="4.1.0b1"
+scriptVersion="4.1.0b2"
 
 # Client-side Log
 scriptLog="/var/log/org.churchofjesuschrist.log"
@@ -6604,12 +6604,13 @@ function checkFirewall() {
 function checkUptime() {
 
     local humanReadableCheckName="Uptime"
-    notice "Check ${humanReadableCheckName} ..."
+    local footerStatusColor="${statusColorSuccess}"
+    notice "Check ${humanReadableCheckName} …"
 
     dialogUpdate "icon: SF=stopwatch,${organizationColorScheme}"
-    dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill $(echo "${organizationColorScheme}" | tr ',' ' '), iconalpha: 1, status: wait, statustext: Checking ..."
+    dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill $(echo "${organizationColorScheme}" | tr ',' ' '), iconalpha: 1, status: wait, statustext: Checking …"
     dialogUpdate "progress: increment"
-    dialogUpdate "progresstext: Calculating time since last reboot ..."
+    dialogUpdate "progresstext: Calculating time since last reboot …"
 
     sleep "${anticipationDuration}"
 
@@ -6660,11 +6661,13 @@ function checkUptime() {
 
             "warning" )
                 dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=bold colour=${statusColorError}, iconalpha: 1, subtitle: ${uptimeExtendedStatus}, status: error, statustext: ${uptimeHumanReadable}"
+                footerStatusColor="${statusColorError}"
                 warning "${humanReadableCheckName}: ${uptimeHumanReadable}: ${uptimeExtendedStatus}"
                 ;;
 
             "error" | * )
                 dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=bold colour=${statusColorFail}, iconalpha: 1, subtitle: ${uptimeExtendedStatus}, status: fail, statustext: ${uptimeHumanReadable}"
+                footerStatusColor="${statusColorFail}"
                 errorOut "${humanReadableCheckName}: ${uptimeHumanReadable}: ${uptimeExtendedStatus}"
                 overallHealth+="${humanReadableCheckName}; "
                 ;;
@@ -6672,10 +6675,15 @@ function checkUptime() {
         esac
     else
         dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=semibold colour=${statusColorSuccess}, iconalpha: 0.6, subtitle: ${uptimeExtendedStatus}, status: success, statustext: ${uptimeHumanReadable}"
+        footerStatusColor="${statusColorSuccess}"
         info "${humanReadableCheckName}: ${uptimeHumanReadable}: ${uptimeExtendedStatus}"
     fi
 
+    dialogUpdate "icon: SF=stopwatch,weight=semibold,colour=${footerStatusColor}"
+    sleep $((anticipationDuration / 2))
+
 }
+
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #

--- a/Mac-Health-Check.zsh
+++ b/Mac-Health-Check.zsh
@@ -17,7 +17,7 @@
 #
 # HISTORY
 #
-# Version 4.1.0b2, 17-Jul-2026, Dan K. Snelson (@dan-snelson)
+# Version 4.1.0b3, 13-Aug-2026, Dan K. Snelson (@dan-snelson)
 # - See CHANGELOG.md for details
 #
 ####################################################################################################
@@ -33,7 +33,7 @@
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/
 
 # Script Version
-scriptVersion="4.1.0b2"
+scriptVersion="4.1.0b3"
 
 # Client-side Log
 scriptLog="/var/log/org.churchofjesuschrist.log"
@@ -5824,9 +5824,29 @@ function checkStagedUpdate() {
     local stagedUpdateSize="0"
     local stagedUpdateLocation="Not detected"
     local stagedUpdateStatus="Pending download"
+    local stagedSnapshotTimeoutSeconds="10"
+    local snapshotListOutput=""
+    local snapshotListExitCode="0"
+    local updateSnapshots="0"
     
     # Check for APFS snapshots indicating staged updates
-    local updateSnapshots=$(/usr/sbin/diskutil apfs listsnapshots / 2>/dev/null | grep -c "com.apple.os.update")
+    snapshotListOutput="$( captureCommandOutputWithTimeout "${stagedSnapshotTimeoutSeconds}" /usr/sbin/diskutil apfs listsnapshots / )"
+    snapshotListExitCode="$?"
+    case "${snapshotListExitCode}" in
+        "0" )
+            ;;
+        "124" )
+            info "APFS snapshot check timed out after ${stagedSnapshotTimeoutSeconds} seconds; continuing with Preboot staging checks."
+            ;;
+        * )
+            info "APFS snapshot check returned exit ${snapshotListExitCode}; continuing with Preboot staging checks."
+            ;;
+    esac
+
+    updateSnapshots="$( printf '%s' "${snapshotListOutput}" | grep -c "com.apple.os.update" )"
+    if [[ "${updateSnapshots}" != <-> ]]; then
+        updateSnapshots="0"
+    fi
     
     if [[ ${updateSnapshots} -gt 0 ]]; then
         info "Found ${updateSnapshots} update snapshot(s)"

--- a/Mac-Health-Check.zsh
+++ b/Mac-Health-Check.zsh
@@ -17,7 +17,7 @@
 #
 # HISTORY
 #
-# Version 4.1.0b4, 13-Aug-2026, Dan K. Snelson (@dan-snelson)
+# Version 4.1.0b6, 13-Aug-2026, Dan K. Snelson (@dan-snelson)
 # - See CHANGELOG.md for details
 #
 ####################################################################################################
@@ -33,7 +33,7 @@
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/
 
 # Script Version
-scriptVersion="4.1.0b4"
+scriptVersion="4.1.0b6"
 
 # Client-side Log
 scriptLog="/var/log/org.churchofjesuschrist.log"
@@ -8556,10 +8556,11 @@ function checkBluetoothSharing() {
     sleep "${anticipationDuration}"
     
     # Check Bluetooth sharing settings using -currentHost as per macOS Security Compliance Project
-    local result=$( captureRunAsUserOutput defaults -currentHost read com.apple.Bluetooth PrefKeyServicesEnabled )
-    
-    # If the key doesn't exist or is 0, Bluetooth sharing is disabled (compliant)
-    if [[ "${result}" == "0" ]] || [[ "${result}" =~ "does not exist" ]]; then
+    local result=""
+    result=$( captureRunAsUserOutput defaults -currentHost read com.apple.Bluetooth PrefKeyServicesEnabled )
+
+    # A missing preference retains macOS's disabled default; macOS 27 reports a missing domain differently.
+    if [[ "${result}" == "0" ]] || [[ "${result}" == *"does not exist"* ]] || [[ "${result}" == "Error: Domain 'com.apple.Bluetooth' not found." ]]; then
         info "${humanReadableCheckName}: Disabled"
         dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=semibold colour=${statusColorSuccess}, iconalpha: 0.9, subtitle: ${organizationBoilerplateComplianceMessage}, status: success, statustext: Disabled"
     else
@@ -8668,7 +8669,7 @@ function checkAirPlayReceiver() {
         if [[ "${osMajorVersion}" -eq 15 && "${osMinorVersion}" -ge 7 ]]; then
             # 15.7.x: assume Enabled when key is missing
             errorOut "${humanReadableCheckName}: Enabled (no ${keyFound:-AirplayReceiverEnabled} key; default behavior on macOS ${osMajorVersion}.${osMinorVersion})"
-            dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=bold colour=${statusColorFail}, iconalpha: 1, subtitle: System Settings > General > AirDrop & Handoff > AirPlay Receiver > Disable, status: fail, statustext: Enabled"
+            dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=bold colour=${statusColorFail}, iconalpha: 1, subtitle: System Settings > General > AirDrop & Continuity > AirPlay Receiver > Disable, status: fail, statustext: Enabled"
             overallHealth+="${humanReadableCheckName}; "
             footerStatusColor="${statusColorFail}"
         else
@@ -8685,7 +8686,7 @@ function checkAirPlayReceiver() {
     elif [[ "${result}" == "1" ]]; then
         # Value is 1, enabled (non-compliant)
         errorOut "${humanReadableCheckName}: Enabled (${keyFound}=${result})"
-        dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=bold colour=${statusColorFail}, iconalpha: 1, subtitle: System Settings > General > AirDrop & Handoff > AirPlay Receiver > Disable, status: fail, statustext: Enabled"
+        dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=bold colour=${statusColorFail}, iconalpha: 1, subtitle: System Settings > General > AirDrop & Continuity > AirPlay Receiver > Disable, status: fail, statustext: Enabled"
         overallHealth+="${humanReadableCheckName}; "
         footerStatusColor="${statusColorFail}"
 
@@ -8697,7 +8698,7 @@ function checkAirPlayReceiver() {
     else
         # Unexpected value
         warning "${humanReadableCheckName}: Unexpected value (${keyFound}=${result})"
-        dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=bold colour=${statusColorError}, iconalpha: 1, subtitle: System Settings > General > AirDrop & Handoff > AirPlay Receiver > Disable, status: error, statustext: Status Unknown"
+        dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=bold colour=${statusColorError}, iconalpha: 1, subtitle: System Settings > General > AirDrop & Continuity > AirPlay Receiver > Disable, status: error, statustext: Status Unknown"
         footerStatusColor="${statusColorError}"
     fi
 
@@ -8734,7 +8735,7 @@ function checkAirDropSettings() {
         dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=semibold colour=${statusColorSuccess}, iconalpha: 0.9, subtitle: ${organizationBoilerplateComplianceMessage}, status: success, statustext: Compliant"
     else
         errorOut "${humanReadableCheckName}: Discoverable by Everyone (value: ${result})"
-        dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=bold colour=${statusColorFail}, iconalpha: 1, subtitle: System Settings > General > AirDrop & Handoff > AirDrop > No One / Contacts Only, status: fail, statustext: Everyone"
+        dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=bold colour=${statusColorFail}, iconalpha: 1, subtitle: System Settings > General > AirDrop & Continuity > AirDrop > No One / Contacts Only, status: fail, statustext: Everyone"
         overallHealth+="${humanReadableCheckName}; "
         footerStatusColor="${statusColorFail}"
     fi
@@ -8837,7 +8838,7 @@ if [[ "${operationMode}" == "Development" ]]; then
 
     developmentListitemJSON='
     [
-        {"title" : "Entra ID Registration", "subtitle" : "Checks Microsoft Entra registration for current user context", "icon" : "SF=19.circle,'"${organizationColorScheme}"'", "status" : "pending", "statustext" : "Pending …", "iconalpha" : 0.5}
+        {"title" : "Bluetooth Sharing", "subtitle" : "Ensure Bluetooth Sharing is disabled when not needed", "icon" : "SF=19.circle,'"${organizationColorScheme}"'", "status" : "pending", "statustext" : "Pending …", "iconalpha" : 0.5}
     ]
     '
     # Validate developmentListitemJSON is valid JSON
@@ -8981,9 +8982,9 @@ if [[ "${operationMode}" == "Development" ]]; then
     # Operation Mode: Development
     notice "Operation Mode is ${operationMode}; using ${operationMode}-specific Health Check."
     dialogUpdate "title: ${humanReadableScriptName} (${scriptVersion})<br>Operation Mode: ${operationMode}"
-    # set -x
-    checkEntraIDRegistration "0"
-    # set +x
+    set -x
+    checkBluetoothSharing "0"
+    set +x
 
 else
 

--- a/Mac-Health-Check.zsh
+++ b/Mac-Health-Check.zsh
@@ -5822,7 +5822,7 @@ function checkStagedUpdate() {
     local stagedUpdateStatus="Pending download"
     
     # Check for APFS snapshots indicating staged updates
-    local updateSnapshots=$(tmutil listlocalsnapshots / 2>/dev/null | grep -c "com.apple.os.update")
+    local updateSnapshots=$(/usr/sbin/diskutil apfs listsnapshots / 2>/dev/null | grep -c "com.apple.os.update")
     
     if [[ ${updateSnapshots} -gt 0 ]]; then
         info "Found ${updateSnapshots} update snapshot(s)"

--- a/Mac-Health-Check.zsh
+++ b/Mac-Health-Check.zsh
@@ -17,7 +17,7 @@
 #
 # HISTORY
 #
-# Version 4.0.0, 14-Jul-2026, Dan K. Snelson (@dan-snelson)
+# Version 4.1.0b1, 17-Jul-2026, Dan K. Snelson (@dan-snelson)
 # - See CHANGELOG.md for details
 #
 ####################################################################################################
@@ -33,7 +33,7 @@
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/
 
 # Script Version
-scriptVersion="4.0.0"
+scriptVersion="4.1.0b1"
 
 # Client-side Log
 scriptLog="/var/log/org.churchofjesuschrist.log"

--- a/Mac-Health-Check.zsh
+++ b/Mac-Health-Check.zsh
@@ -397,6 +397,7 @@ allowedUptimeMinutes="10080"
 maxUptimeMinutes="43200"
 
 # Should excessive uptime result in a "warning" or "error" ?
+# Setting this to error will disable the max uptime check above
 excessiveUptimeAlertStyle="warning"
 
 # Completion Timer (in seconds)
@@ -6634,31 +6635,44 @@ function checkUptime() {
     else
         uptimeHumanReadable="${uptimeNumber} (HH:MM)"
     fi
+    
+    if [[ "${maxUptimeMinutes}" =~ '^[1-9][0-9]*$' ]]; then
+        if [[ "${allowedUptimeMinutes}" -gt "${maxUptimeMinutes}" ]]; then
+            warning "${humanReadableCheckName}: Error in configuration: Variable allowedUptimeMinutes is greater than maxUptimeMinutes. Maximum uptime check disabled."
+            maxUptimeMinutes=""
+        elif [[ -n "${maxUptimeMinutes}" ]] && [[ "${excessiveUptimeAlertStyle}" == "error" ]]; then
+            warning "${humanReadableCheckName}: Error in configuration: Variable excessiveUptimeAlertStyle is set to error instead of warning. Maximum uptime check disabled."
+            maxUptimeMinutes=""
+        fi
+    else
+            warning "${humanReadableCheckName}: Error in configuration: Variable maxUptimeMinutes is not a postive integer. Maximum uptime check disabled."
+            maxUptimeMinutes=""
+    fi
 
-    if [[ "${upTimeMin}" -gt "${maxUptimeMinutes}" ]] && [[ -n "${maxUptimeMinutes}" ]]; then
-        uptimeExtendedStatus="Your Mac's uptime is beyond the maximum 30 days allowed."
+    if [[ -n "${maxUptimeMinutes}" ]] && [[ "${upTimeMin}" -gt "${maxUptimeMinutes}" ]]; then
+        local uptimeExtendedStatus="Your Mac's uptime is beyond the maximum allowed by your organization."
         dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=bold colour=${statusColorFail}, iconalpha: 1, subtitle: ${uptimeExtendedStatus}, status: fail, statustext: ${uptimeHumanReadable}"
-        errorOut "${humanReadableCheckName}: ${uptimeHumanReadable}: "
+        errorOut "${humanReadableCheckName}: ${uptimeHumanReadable}: ${uptimeExtendedStatus}"
         overallHealth+="${humanReadableCheckName}; "
     elif [[ "${upTimeMin}" -gt "${allowedUptimeMinutes}" ]]; then
-        uptimeExtendedStatus="Please restart your Mac regularly. "
+        local uptimeExtendedStatus="Please restart your Mac regularly. "
         case ${excessiveUptimeAlertStyle} in
 
             "warning" )
                 dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=bold colour=${statusColorError}, iconalpha: 1, subtitle: ${uptimeExtendedStatus}, status: error, statustext: ${uptimeHumanReadable}"
-                warning "${humanReadableCheckName}: ${uptimeHumanReadable}: "
+                warning "${humanReadableCheckName}: ${uptimeHumanReadable}: ${uptimeExtendedStatus}"
                 ;;
 
-            "error" )
+            "error" | * )
                 dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=bold colour=${statusColorFail}, iconalpha: 1, subtitle: ${uptimeExtendedStatus}, status: fail, statustext: ${uptimeHumanReadable}"
-                errorOut "${humanReadableCheckName}: ${uptimeHumanReadable}: "
+                errorOut "${humanReadableCheckName}: ${uptimeHumanReadable}: ${uptimeExtendedStatus}"
                 overallHealth+="${humanReadableCheckName}; "
                 ;;
 
         esac
     else
         dialogUpdate "listitem: index: ${1}, icon: SF=$(printf "%02d" $(($1+1))).circle.fill weight=semibold colour=${statusColorSuccess}, iconalpha: 0.6, subtitle: ${uptimeExtendedStatus}, status: success, statustext: ${uptimeHumanReadable}"
-        info "${humanReadableCheckName}: ${uptimeHumanReadable}: "   
+        info "${humanReadableCheckName}: ${uptimeHumanReadable}: ${uptimeExtendedStatus}"
     fi
 
 }

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Mac Health Check is particularly valuable in IT support workflows, serving as an
 
 ### :new: Enterprise Reporting
 
-The tool logs results for review, writes a structured JSON health report locally, can optionally forward that report to Splunk HEC, and continues to avoid altering device configuration. In `Self Service`, `4.0.0` launches a detached swiftDialog Inspect Mode `preset6` guided summary built from finalized in-memory results plus a live compliance plist for swiftDialog `3.1.0.4994` compliance findings. The summary adds a remediation-first flow with `Quick Actions`, a conditional `Remediation Guide`, status-aware bento-grid cards, `compliance-summary`, `findings-list`, and the existing `Unhealthy` / `Healthy` details, while retaining the main dialog's 60-second completion countdown. Full `Silent` health-check runs generate the same Inspect Mode config and compliance plist artifacts without launching swiftDialog. Reruns within 15 minutes can replay that cached summary without re-running health checks, and runs with health issues rely on the final main-dialog state plus that detached inspect summary instead of a separate pseudo-alert notification.
+The tool logs results for review, writes a structured JSON health report locally, can optionally forward that report to Splunk HEC, and continues to avoid altering device configuration. In `Self Service`, `4.1.0` launches a detached swiftDialog Inspect Mode `preset6` guided summary built from finalized in-memory results plus a live compliance plist for swiftDialog `3.1.0.4994` compliance findings. The summary adds a remediation-first flow with `Quick Actions`, a conditional `Remediation Guide`, status-aware bento-grid cards, `compliance-summary`, `findings-list`, and the existing `Unhealthy` / `Healthy` details, while retaining the main dialog's 60-second completion countdown. Full `Silent` health-check runs generate the same Inspect Mode config and compliance plist artifacts without launching swiftDialog. Reruns within 15 minutes can replay that cached summary without re-running health checks, and runs with health issues rely on the final main-dialog state plus that detached inspect summary instead of a separate pseudo-alert notification.
 
 - Structured JSON health report generated at the end of every run
 - Local report saved to `/var/tmp/MacHealthCheck-Report.json` by default with `600` permissions
@@ -51,7 +51,7 @@ The tool logs results for review, writes a structured JSON health report locally
 - Parameters 9 and 10 set the HEC `index` and `sourcetype`; Parameter 11 forces a fresh run
 - `splunkOperationMode=off` disables HEC delivery explicitly while still preserving local JSON report generation
 - `splunkOperationMode=test` preserves local report generation while intentionally skipping network transmission
-- In `4.0.0`, non-`Silent` runs and full Jamf production runs install a client-side copy at `/Library/Management/org.churchofjesuschrist/MHC.zsh` plus a `org.churchofjesuschrist.MHC` LaunchDaemon that refreshes the local report across a deterministic 00:53-01:53 window centered on 1:23 a.m.
+- Beginning in `4.0.0`, non-`Silent` runs and full Jamf production runs install a client-side copy at `/Library/Management/org.churchofjesuschrist/MHC.zsh` plus a `org.churchofjesuschrist.MHC` LaunchDaemon that refreshes the local report across a deterministic 00:53-01:53 window centered on 1:23 a.m.
 - The LaunchDaemon sets `launchDaemonRun=true`; the client-side script then derives a stable per-Mac jitter from hardware UUID, logs the jitter through MHC-prefixed logging, and routes daemon stdout/stderr to `/dev/null` to avoid duplicate client-log lines.
 - When a LaunchDaemon-triggered refresh runs with no active GUI user, Mac Health Check falls back to `/Library/Preferences/com.apple.loginwindow.plist` `lastUserName` for user-scoped checks.
 - Jamf Pro `Silent` + `splunkOperationMode=production` runs upload the cached report without re-running checks when the client-side script version matches and `/var/tmp/MacHealthCheck-Report.json` is valid and less than 36 hours old
@@ -64,7 +64,7 @@ See: [Resources/Splunk-Dashboard-Reference.md](Resources/Splunk-Dashboard-Refere
 
 The `inspectSummaryPreset` is now an `on` / `off` toggle: `on` generates the Preset 6 inspect-summary assets, launches the summary in `Self Service`, and enables cached replay; `off` disables asset generation, launch, and replay.
 
-The current `4.0.0` beta targets swiftDialog `3.1.0.4994` or newer so `Self Service` can use the PR #684 Preset 6 spacing and highlight refinements. Until RC2 is published, the existing non-production fallback permits older compatible swiftDialog builds to render the same schema-valid config with their prior visual treatment. PR #684 also tolerates quoted scalar values from MDM templating tools; Mac Health Check continues to emit native JSON numbers and booleans.
+The current `4.1.0` release targets swiftDialog `3.1.0.4994` or newer so `Self Service` can use the PR #684 Preset 6 spacing and highlight refinements. Older compatible swiftDialog builds retain their prior visual treatment. PR #684 also tolerates quoted scalar values from MDM templating tools; Mac Health Check continues to emit native JSON numbers and booleans.
 
 User-facing report:
 
@@ -155,9 +155,9 @@ organizationDirectory="/Library/Management/org.churchofjesuschrist"
 - If dock icon setup fails, Mac Health Check logs a warning and falls back to the default `/usr/local/bin/dialog` launch path
 
 ## Features
-The following health checks and information reporting are included in version `4.0.0`, which operates in `Self Service` mode by default. (Change `operationMode` to `Debug`, `Development` or `Test` when getting ready to deploy in production.)
+The following health checks and information reporting are included in version `4.1.0`, which operates in `Self Service` mode by default. (Change `operationMode` to `Debug`, `Development` or `Test` when getting ready to deploy in production.)
 
-> :new: Mac Health Check version `4.0.0` retains secure JSON report generation and optional Splunk HEC delivery, adds Client-Side Cache nightly report caching for Jamf Pro Splunk uploads, updates Inspect Mode summary assets for swiftDialog `3.1.0.4994` PR #684 refinements, adds `Quick Actions`, a conditional `Remediation Guide`, status-aware 12-point bento-grid spacing, and a status-aware Overview highlight, writes those assets during full `Silent` health-check runs without launching UI, supports 15-minute cached summary replay on rerun, and retains `Wi-Fi Strength` plus warning-only final dialog handling via `Computer Needs Attention`.
+> :new: Mac Health Check version `4.1.0` retains secure JSON report generation and optional Splunk HEC delivery, Client-Side Cache nightly report caching for Jamf Pro Splunk uploads, Inspect Mode summary assets for swiftDialog `3.1.0.4994` PR #684 refinements, `Quick Actions`, a conditional `Remediation Guide`, status-aware 12-point bento-grid spacing, full `Silent` Inspect asset generation without launching UI, 15-minute cached summary replay on rerun, `Wi-Fi Strength`, and warning-only final dialog handling via `Computer Needs Attention`, while improving Bluetooth Sharing, staged-update, uptime, and detached-summary behavior.
 
 
 
@@ -387,7 +387,7 @@ Deployment of Mac Health Check involves configuring organizational defaults, upl
 
 A new "Development" Operation Mode has been added to aid in developing Health Checks, allowing quick runs against a small curated subset instead of the full suite.
 
-When `operationMode` is set to `Development`, `4.0.0` uses a dedicated `developmentListitemJSON` for `AirDrop` plus `Wi-Fi Strength` instead of running the entire suite.
+When `operationMode` is set to `Development`, `4.1.0` uses a dedicated `developmentListitemJSON` for `Bluetooth Sharing` instead of running the entire suite.
 
 ```zsh
 ####################################################################################################
@@ -435,9 +435,9 @@ if [[ "${operationMode}" == "Development" ]]; then
     # Operation Mode: Development
     notice "Operation Mode is ${operationMode}; using ${operationMode}-specific Health Check."
     dialogUpdate "title: ${humanReadableScriptName} (${scriptVersion})<br>Operation Mode: ${operationMode}"
-    set -x
+    # set -x
     checkBluetoothSharing "0"
-    set +x
+    # set +x
 
 else
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/dan-snelson/Mac-Health-Check?display_name=tag) ![GitHub pre-release (latest by date)](https://img.shields.io/github/v/release/dan-snelson/Mac-Health-Check?display_name=tag&include_prereleases) ![GitHub issues](https://img.shields.io/github/issues-raw/dan-snelson/Mac-Health-Check) ![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/dan-snelson/Mac-Health-Check) ![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/dan-snelson/Mac-Health-Check) ![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed-raw/dan-snelson/Mac-Health-Check) [![swiftDialog](https://img.shields.io/badge/swiftDialog-Enabled-blue)](https://swiftdialog.app) [![Semgrep Security Scan](https://img.shields.io/badge/security%20scanned%20by-Semgrep-00C7B7?style=flat&logo=semgrep&logoColor=white)](https://semgrep.dev)
 
-# Mac Health Check (4.1.0b2)
+# Mac Health Check (4.1.0b3)
 
 > A **major** update to the practical, MDM-agnostic, user-friendly approach to surfacing Mac compliance information directly to end-users — and now **enterprise reporting data warehouses** — via your MDM's self-service app
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/dan-snelson/Mac-Health-Check?display_name=tag) ![GitHub pre-release (latest by date)](https://img.shields.io/github/v/release/dan-snelson/Mac-Health-Check?display_name=tag&include_prereleases) ![GitHub issues](https://img.shields.io/github/issues-raw/dan-snelson/Mac-Health-Check) ![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/dan-snelson/Mac-Health-Check) ![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/dan-snelson/Mac-Health-Check) ![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed-raw/dan-snelson/Mac-Health-Check) [![swiftDialog](https://img.shields.io/badge/swiftDialog-Enabled-blue)](https://swiftdialog.app) [![Semgrep Security Scan](https://img.shields.io/badge/security%20scanned%20by-Semgrep-00C7B7?style=flat&logo=semgrep&logoColor=white)](https://semgrep.dev)
 
-# Mac Health Check (4.1.0b4)
+# Mac Health Check (4.1.0b6)
 
 > A **major** update to the practical, MDM-agnostic, user-friendly approach to surfacing Mac compliance information directly to end-users — and now **enterprise reporting data warehouses** — via your MDM's self-service app
 
@@ -408,7 +408,7 @@ if [[ "${operationMode}" == "Development" ]]; then
 
     developmentListitemJSON='
     [
-        {"title" : "Entra ID Registration", "subtitle" : "Checks Microsoft Entra registration for current user context", "icon" : "SF=19.circle,'"${organizationColorScheme}"'", "status" : "pending", "statustext" : "Pending …", "iconalpha" : 0.5}
+        {"title" : "Bluetooth Sharing", "subtitle" : "Ensure Bluetooth Sharing is disabled when not needed", "icon" : "SF=19.circle,'"${organizationColorScheme}"'", "status" : "pending", "statustext" : "Pending …", "iconalpha" : 0.5}
     ]
     '
     # Validate developmentListitemJSON is valid JSON
@@ -435,9 +435,9 @@ if [[ "${operationMode}" == "Development" ]]; then
     # Operation Mode: Development
     notice "Operation Mode is ${operationMode}; using ${operationMode}-specific Health Check."
     dialogUpdate "title: ${humanReadableScriptName} (${scriptVersion})<br>Operation Mode: ${operationMode}"
-    # set -x
-    checkEntraIDRegistration "0"
-    # set +x
+    set -x
+    checkBluetoothSharing "0"
+    set +x
 
 else
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/dan-snelson/Mac-Health-Check?display_name=tag) ![GitHub pre-release (latest by date)](https://img.shields.io/github/v/release/dan-snelson/Mac-Health-Check?display_name=tag&include_prereleases) ![GitHub issues](https://img.shields.io/github/issues-raw/dan-snelson/Mac-Health-Check) ![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/dan-snelson/Mac-Health-Check) ![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/dan-snelson/Mac-Health-Check) ![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed-raw/dan-snelson/Mac-Health-Check) [![swiftDialog](https://img.shields.io/badge/swiftDialog-Enabled-blue)](https://swiftdialog.app) [![Semgrep Security Scan](https://img.shields.io/badge/security%20scanned%20by-Semgrep-00C7B7?style=flat&logo=semgrep&logoColor=white)](https://semgrep.dev)
 
-# Mac Health Check (4.1.0b3)
+# Mac Health Check (4.1.0b4)
 
 > A **major** update to the practical, MDM-agnostic, user-friendly approach to surfacing Mac compliance information directly to end-users — and now **enterprise reporting data warehouses** — via your MDM's self-service app
 
@@ -241,7 +241,7 @@ Jamf Pro inventory submission is a final follow-up action. In full Jamf Pro runs
 - Unhealthy runs now surface `Quick Actions Recommended` in `Overview`, add a conditional `Remediation Guide` step immediately after `Overview`, and keep `Unhealthy` as the audit-detail step
 - Category bento-grid cards now use status-aware backgrounds so unhealthy checks stand out more clearly in Preset 6, and `Available Updates` now expands across two columns when action is required
 - Plist-backed bento cells now emit FR #667 detail-sheet fields (`severity`, `explanation`, `remediation`, `actionButtonText`, `actionURL`) so warning and failure cards can explain why action is needed and link directly to next steps
-- Normal `Self Service` runs launch the detached swiftDialog Inspect Mode `preset6` guided summary after report generation while retaining the existing 60-second main-dialog countdown
+- Normal `Self Service` runs launch the detached, always-on-top, moveable swiftDialog Inspect Mode `preset6` guided summary after report generation while retaining the existing 60-second main-dialog countdown
 - `Silent` runs never launch swiftDialog; they only write Inspect Mode config assets for later review
 - The detached summary now separates recorded results into `Unhealthy` and `Healthy` sections and omits either section when no checks exist in that bucket
 - Re-running `zsh Mac-Health-Check.zsh` within `inspectReplayMaximumAgeSeconds` (i.e., 15 minutes), replays the cached inspect summary immediately and skips the health checks plus the main dialog countdown

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/dan-snelson/Mac-Health-Check?display_name=tag) ![GitHub pre-release (latest by date)](https://img.shields.io/github/v/release/dan-snelson/Mac-Health-Check?display_name=tag&include_prereleases) ![GitHub issues](https://img.shields.io/github/issues-raw/dan-snelson/Mac-Health-Check) ![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/dan-snelson/Mac-Health-Check) ![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/dan-snelson/Mac-Health-Check) ![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed-raw/dan-snelson/Mac-Health-Check) [![swiftDialog](https://img.shields.io/badge/swiftDialog-Enabled-blue)](https://swiftdialog.app) [![Semgrep Security Scan](https://img.shields.io/badge/security%20scanned%20by-Semgrep-00C7B7?style=flat&logo=semgrep&logoColor=white)](https://semgrep.dev)
 
-# Mac Health Check (4.0.0)
+# Mac Health Check (4.1.0b2)
 
 > A **major** update to the practical, MDM-agnostic, user-friendly approach to surfacing Mac compliance information directly to end-users — and now **enterprise reporting data warehouses** — via your MDM's self-service app
 
@@ -48,7 +48,7 @@ The tool logs results for review, writes a structured JSON health report locally
 - Structured JSON health report generated at the end of every run
 - Local report saved to `/var/tmp/MacHealthCheck-Report.json` by default with `600` permissions
 - Optional Splunk HEC delivery through Parameters 6-11 without changing the existing `operationMode` contract
-- Parameters 9 and 10 set the HEC `index` and `sourcetype`; Parameter 11 enables reporting debug output
+- Parameters 9 and 10 set the HEC `index` and `sourcetype`; Parameter 11 forces a fresh run
 - `splunkOperationMode=off` disables HEC delivery explicitly while still preserving local JSON report generation
 - `splunkOperationMode=test` preserves local report generation while intentionally skipping network transmission
 - In `4.0.0`, non-`Silent` runs and full Jamf production runs install a client-side copy at `/Library/Management/org.churchofjesuschrist/MHC.zsh` plus a `org.churchofjesuschrist.MHC` LaunchDaemon that refreshes the local report across a deterministic 00:53-01:53 window centered on 1:23 a.m.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/dan-snelson/Mac-Health-Check?display_name=tag) ![GitHub pre-release (latest by date)](https://img.shields.io/github/v/release/dan-snelson/Mac-Health-Check?display_name=tag&include_prereleases) ![GitHub issues](https://img.shields.io/github/issues-raw/dan-snelson/Mac-Health-Check) ![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/dan-snelson/Mac-Health-Check) ![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/dan-snelson/Mac-Health-Check) ![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed-raw/dan-snelson/Mac-Health-Check) [![swiftDialog](https://img.shields.io/badge/swiftDialog-Enabled-blue)](https://swiftdialog.app) [![Semgrep Security Scan](https://img.shields.io/badge/security%20scanned%20by-Semgrep-00C7B7?style=flat&logo=semgrep&logoColor=white)](https://semgrep.dev)
 
-# Mac Health Check (4.1.0b6)
+# Mac Health Check (4.1.0)
 
-> A **major** update to the practical, MDM-agnostic, user-friendly approach to surfacing Mac compliance information directly to end-users — and now **enterprise reporting data warehouses** — via your MDM's self-service app
+> Mac Health Check 4.1.0 sharpens macOS compliance reporting with smarter Bluetooth Sharing detection, safer staged-update checks, richer uptime insight and a more user-friendly reporting summary
 
 <img src="images/MHC_4.0.0.png" alt="Mac Health Check Hero" width="800"/>
 

--- a/README.md
+++ b/README.md
@@ -163,10 +163,10 @@ The following health checks and information reporting are included in version `4
 
 ### Health Checks
 
-:tada: Improved in version `4.0.0`
+:tada: Improved in version `4.1.0`
 
 1. macOS Version
-1. Available Updates (including deferred and DDM-enforced updates)
+1. :tada: Available Updates (including deferred, staged, and DDM-enforced updates)
 1. System Integrity Protection
 1. Signed System Volume (SSV)
 1. Firewall
@@ -176,16 +176,16 @@ The following health checks and information reporting are included in version `4
 1. Password Hint
 1. AirDrop
 1. AirPlay Receiver
-1. Bluetooth Sharing
+1. :tada: Bluetooth Sharing
 1. VPN Client
-1. Last Reboot
+1. :tada: Last Reboot
 1. Free Disk Space
 1. User's Directory Size and Item Count
     - Desktop
     - Downloads
     - Trash
 1. MDM Profile
-1. :new: Entra ID Registration
+1. Entra ID Registration
 1. MDM Certificate Expiration
 1. Apple Push Notification service
 1. Jamf Pro Check-in
@@ -200,7 +200,7 @@ The following health checks and information reporting are included in version `4
 1. Wi-Fi Strength
 1. App Auto-Patch
 1. Homebrew Status
-1. :tada: Electron Corner Mask [🔗](https://avarayr.github.io/shamelectron/)
+1. Electron Corner Mask [🔗](https://avarayr.github.io/shamelectron/)
 1. Organizationally required Applications (i.e., Microsoft Teams)
 1. BeyondTrust Privilege Management*
 1. Cisco Umbrella*


### PR DESCRIPTION
### 4.1.0 (17-Aug-2026)
- Refactored `checkBluetoothSharing()` to recognize the macOS 27 missing-domain response as the disabled default, preventing false-positive Bluetooth Sharing findings while preserving enabled-state detection on macOS 26 and macOS 27
- Updated detached Inspect Mode Preset 6 dialogs to remain on top and allow users to move the window (thanks for the suggestion, @TechTrekkie!)
- Hardened staged macOS update snapshot detection to use APFS-native `diskutil` with timeout-safe fallback behavior (thanks for PR #99, @HowardGMac!)
- Updated `checkUptime()` with new functionality (thanks for PR #96, @HowardGMac!)
- Standardized `checkUptime()`